### PR TITLE
feat: update instructions to install from conda/mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ cd ..
 pip install -e .
 ```
 
+## [Conda/mamba](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html) installation
+
+```bash
+mamba create -n madmjx python=3.11
+mamba activate madmjx
+mamba install cuda==12.5.1 cudnn cuda-nvcc cmake
+mamba install xorg-xorgproto # yes, for some reason, this has to be installed separately
+pip install "jax[cuda12_local]" mujoco-mjx mujoco brax
+mkdir build && cd build
+cmake .. -DLOAD_VULKAN=OFF
+make -j
+
+cd ..
+pip install -e .
+```
+
+> Note: In case running scripts/viewer.py fails due missing cuda libraries, update environment by setting `export XLA_FLAGS=--xla_gpu_cuda_data_dir=$CONDA_PREFIX`
+
+> Note: In case you have issues with rendering the viewer, update environment by setting `export PYGLFW_LIBRARY_VARIANT=x11`
+
 > If you are on a machine which doesn't have Vulkan installed (i.e., when you run a script, you run into an assertion failure at `madrona::render::vk::Backend::Init::init`), make sure to replace `cmake ..` with `cmake -DLOAD_VULKAN=OFF ..` so that the application doesn't try to load Vulkan.
 
 - In the case that running `cmake` does not work, check your cmake version with `cmake --version` and try updating to at least [cmake 3.31.0](https://github.com/Kitware/CMake/releases/download/v3.31.0-rc2/cmake-3.31.0-rc2-linux-x86_64.sh).


### PR DESCRIPTION
Hello, @shacklettbp !

I have been following the instructions from `mujoco_playground` to run vision-based policies and faced some issues with installing `madrona_mjx`. At first, I am not a fan of installing something directly into the system as in `apt-get install ...`, moreover the system of user may be different. Therefore, I have put some time into testing the setup for compilation using `conda/mamba` environment. Yet this may not be the best solution still, I think it will ease the process for newcomers and boost the possible contributions and development of this bridge.

I am looking forward for your opinion on this.

P.S. Thanks @mattephi for the debugging and help